### PR TITLE
Fix PurgeCacheService.php (Add TryCatch Block)

### DIFF
--- a/src/Mouf/Utils/Cache/Service/PurgeCacheService.php
+++ b/src/Mouf/Utils/Cache/Service/PurgeCacheService.php
@@ -27,8 +27,13 @@ class PurgeCacheService {
 		foreach ($instances as $instanceName) {
 			$cacheService = $moufManager->getInstance($instanceName);
 			/* @var $cacheService CacheInterface */
-		
-			$cacheService->purgeAll();
+			try {
+				$cacheService->purgeAll();	
+			}
+			catch (\Exception $ex) {
+				// FIXME: Throw error on GUI and/or in PHP error log !
+				// EXAMPLE: $log->error($instanceName + " have throw an exception '" + $ex->getMessage() + "' !");
+			}
 		}
 		
 	}


### PR DESCRIPTION
When I have an exception in a CacheService, Other CacheService isn't purge.
A Try-Catch block is necessary but I don't have idea to throw error on GUI. If you have an idea.
